### PR TITLE
Fix misspelling preventing the setting of sandbox in proxy creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function PacProxyAgent (uri, opts) {
   // strip the "pac+" prefix
   this.uri = uri.replace(/^pac\+/i, '');
 
-  this.sandbox = opts.sandox;
+  this.sandbox = opts.sandbox;
 
   this.proxy = opts;
 


### PR DESCRIPTION
The option for sandbox is simply misspelt so it will not be set unless it was passed in as "sandox".  This fixes that.