### PR TITLE
updated get-uri dependency to 2.0; now builds nicely with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "agent-base": "2",
     "debug": "2",
     "extend": "3",
-    "get-uri": "1",
+    "get-uri": "2",
     "http-proxy-agent": "1",
     "https-proxy-agent": "1",
     "pac-resolver": "~1.2.1",


### PR DESCRIPTION
I'm trying to get npm 'mailgun-js' working with webpack. After a lot of tracking, I found this 1-character solution :). This fixes webpack for get-uri, pac-proxy-agent, proxy-agent and, at the end of the chain, mailgun-js.

Thanks!