### PR TITLE
Allow user to pass resolver function directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ http.get(opts, function (res) {
 });
 ```
 
+It is also possible to pass an asynchronous proxy resolver function directly:
+
+``` js
+var agent = new PacProxyAgent(function FindProxyForURL(url, host, cb) {
+  setTimeout(function () {
+    cb(null, "PROXY 127.0.0.1:8080;");
+  });
+});
+```
 
 License
 -------

--- a/index.js
+++ b/index.js
@@ -67,6 +67,10 @@ function PacProxyAgent (uri, opts) {
     } else {
       uri = opts.uri;
     }
+  } else if ('function' === typeof uri) {
+    // user directly passed a resolver
+    this._user_resolver = uri;
+    uri = 'dummy://';
   }
   if (!opts) opts = {};
 
@@ -180,9 +184,13 @@ function connect (req, opts, fn) {
   var self = this;
   var secure = Boolean(opts.secureEndpoint);
 
-  // first we need get a generated FindProxyForURL() function,
-  // either cached or retreived from the source
-  this.loadResolver(onresolver);
+  if (this._user_resolver) {
+    onresolver(null, this._user_resolver);
+  } else {
+    // first we need get a generated FindProxyForURL() function,
+    // either cached or retreived from the source
+    this.loadResolver(onresolver);
+  }
 
   // `loadResolver()` callback function
   function onresolver (err, FindProxyForURL) {


### PR DESCRIPTION
This is useful when using a direct API to resolve proxies, such as electron's [`session.resolveProxy`](https://github.com/electron/electron/blob/master/docs/api/session.md#sesresolveproxyurl-callback)