### PR TITLE
Revert changes that breaks node 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pac-proxy-agent",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A PAC file proxy `http.Agent` implementation for HTTP",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "https-proxy-agent": "^2.2.1",
     "pac-resolver": "^3.0.0",
     "raw-body": "^2.2.0",
-    "socks-proxy-agent": "^4.0.0"
+    "socks-proxy-agent": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "^5.0.5",


### PR DESCRIPTION
Socks-proxy-agent breaks node 4.0 by introducing ES6 syntax