### PR TITLE
added host as servername to tls connection options, if servername is …

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,6 +238,7 @@ function connect (req, opts, fn) {
       // direct connection to the destination endpoint
       var socket;
       if (secure) {
+        opts.servername = opts.servername || opts.host;
         socket = tls.connect(opts);
       } else {
         socket = net.connect(opts);


### PR DESCRIPTION
I had an issue getting an ssl handshake failure error using a PAC based proxy configuration. Turns out `servername` must be provided to `tls.connect()`. I saw you had had it in your other "...-proxy-agent" so I just added the same here