### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "agent-base": "^4.2.0",
     "debug": "^3.1.0",
-    "get-uri": "^2.0.0",
+    "get-uri": "^2.0.3",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "pac-resolver": "^3.0.0",


### PR DESCRIPTION
This is a very minor patch to raise the minimum constraint on "get-uri".
Previous to 2.0.3, the version restrictions in it's package.json meant
it could have pulled in a vulnerable version of "extend" in certain
circumstances. Raising it ensures NPM can't dedupe a vulnerability into
the transitive dependencies.

See https://github.com/TooTallNate/node-get-uri/pull/12 for more detail.