### PR TITLE
Update `https-proxy-agent` to fix a vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pac-proxy-agent",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A PAC file proxy `http.Agent` implementation for HTTP",
   "main": "index.js",
   "scripts": {
@@ -31,7 +31,7 @@
     "debug": "^3.1.0",
     "get-uri": "^2.0.0",
     "http-proxy-agent": "^2.1.0",
-    "https-proxy-agent": "^2.2.1",
+    "https-proxy-agent": "^3.0.0",
     "pac-resolver": "^3.0.0",
     "raw-body": "^2.2.0",
     "socks-proxy-agent": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pac-proxy-agent",
-  "version": "3.1.0",
+  "version": "3.0.0",
   "description": "A PAC file proxy `http.Agent` implementation for HTTP",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
See https://github.com/TooTallNate/node-https-proxy-agent/pull/77

~I took the liberty to bump the version to `3.1.0`, let me know if you want to do this on a separate commit.~