### PR TITLE
fix: recognize SOCKS4, SOCKS5 proxy types

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,9 +243,12 @@ function connect (req, opts, fn) {
         socket = net.connect(opts);
       }
       return fn(null, socket);
-    } else if ('SOCKS' == type) {
-      // use a SOCKS proxy
+    } else if ('SOCKS' == type || 'SOCKS5' == type) {
+      // use a SOCKSv5h proxy
       agent = new SocksProxyAgent('socks://' + parts[1]);
+    } else if ('SOCKS4' == type) {
+      // use a SOCKSv4a proxy
+      agent = new SocksProxyAgent('socks4a://' + parts[1]);
     } else if ('PROXY' == type || 'HTTPS' == type) {
       // use an HTTP or HTTPS proxy
       // http://dev.chromium.org/developers/design-documents/secure-web-proxy

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "mocha": "6",
     "proxy": "^1.0.1",
-    "socksv5": "0.0.6"
+    "socksv5": "0.0.6",
+    "socks4": "0.1.1"
   }
 }


### PR DESCRIPTION
They are among the possible documented PAC entries.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_(PAC)_file