### PR TITLE
Bump up http-proxy-agent version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "agent-base": "^4.2.0",
     "debug": "^4.1.1",
     "get-uri": "^2.0.0",
-    "http-proxy-agent": "^2.1.0",
+    "http-proxy-agent": "^3.0.0",
     "https-proxy-agent": "^3.0.0",
     "pac-resolver": "^3.0.0",
     "raw-body": "^2.2.0",


### PR DESCRIPTION
The fix for Node 12. https://github.com/TooTallNate/node-http-proxy-agent/commit/6884fed51ef0b9059a296551d3337df518b10f5c