### PR TITLE
Trigger `ECONNREFUSED` instead of DNS `ENOENT` for tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -260,9 +260,6 @@ describe('PacProxyAgent', function() {
 		});
 
 		it('should fall back to the next proxy after one fails', function(done) {
-			// This test is slow on Windows :/
-			this.timeout(10000);
-
 			let gotReq = false;
 			httpServer.once('request', function(req, res) {
 				res.end(JSON.stringify(req.headers));
@@ -270,7 +267,7 @@ describe('PacProxyAgent', function() {
 			});
 
 			function FindProxyForURL(url, host) {
-				return 'SOCKS bad-domain:8080; HTTP bad-domain:8080; HTTPS bad-domain:8080; DIRECT;';
+				return 'SOCKS localhost:4; HTTP localhost:4; HTTPS localhost:4; DIRECT;';
 			}
 
 			let uri = `data:,${encodeURIComponent(String(FindProxyForURL))}`;
@@ -389,9 +386,6 @@ describe('PacProxyAgent', function() {
 		});
 
 		it('should fall back to the next proxy after one fails', function(done) {
-			// This test is slow on Windows :/
-			this.timeout(10000);
-
 			let gotReq = false;
 			httpsServer.once('request', function(req, res) {
 				gotReq = true;
@@ -399,7 +393,7 @@ describe('PacProxyAgent', function() {
 			});
 
 			function FindProxyForURL(url, host) {
-				return 'SOCKS bad-domain:8080; HTTP bad-domain:8080; HTTPS bad-domain:8080; DIRECT;';
+				return 'SOCKS localhost:4; HTTP localhost:4; HTTPS localhost:4; DIRECT;';
 			}
 
 			let uri = `data:,${encodeURIComponent(String(FindProxyForURL))}`;

--- a/test/test.js
+++ b/test/test.js
@@ -267,7 +267,7 @@ describe('PacProxyAgent', function() {
 			});
 
 			function FindProxyForURL(url, host) {
-				return 'SOCKS localhost:4; HTTP localhost:4; HTTPS localhost:4; DIRECT;';
+				return 'SOCKS 127.0.0.1:4; HTTP 127.0.0.1:4; HTTPS 127.0.0.1:4; DIRECT;';
 			}
 
 			let uri = `data:,${encodeURIComponent(String(FindProxyForURL))}`;
@@ -393,7 +393,7 @@ describe('PacProxyAgent', function() {
 			});
 
 			function FindProxyForURL(url, host) {
-				return 'SOCKS localhost:4; HTTP localhost:4; HTTPS localhost:4; DIRECT;';
+				return 'SOCKS 127.0.0.1:4; HTTP 127.0.0.1:4; HTTPS 127.0.0.1:4; DIRECT;';
 			}
 
 			let uri = `data:,${encodeURIComponent(String(FindProxyForURL))}`;


### PR DESCRIPTION
Fixes Windows slow tests waiting for DNS to fail.