### PR TITLE
Add `fallbackToDirect` option

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -171,6 +171,10 @@ export default class PacProxyAgent extends Agent {
 			.split(/\s*;\s*/g)
 			.filter(Boolean);
 
+		if (this.opts.fallbackToDirect && !proxies.includes('DIRECT')) {
+			proxies.push('DIRECT');
+		}
+
 		for (const proxy of proxies) {
 			debug('Attempting to use proxy: %o', proxy);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ namespace createPacProxyAgent {
 			HttpsProxyAgentOptions,
 			SocksProxyAgentOptions {
 		uri?: string;
+		fallbackToDirect?: boolean;
 	}
 
 	export type PacProxyAgent = _PacProxyAgent;


### PR DESCRIPTION
Similar to Mozilla's documentation, this is an opt-in feature.

> If all proxies are down, and there was no `DIRECT` option specified,
> the browser will ask if proxies should be temporarily ignored, and
> direct connections attempted.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_(PAC)_file