### PR TITLE
Security: Bump pac-resolver from ^4.1.0 to ^4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "get-uri": "3",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "5",
-    "pac-resolver": "^4.1.0",
+    "pac-resolver": "^4.1.1",
     "raw-body": "^2.2.0",
     "socks-proxy-agent": "5"
   },


### PR DESCRIPTION
Bump pac-resolver from ^4.1.0 to [^4.1.1](https://github.com/TooTallNate/node-pac-resolver/releases/tag/4.1.1)

Tag 4.1.1 includes a single security fix to increment the version of Netmask due to [NPM advisory 1658](https://www.npmjs.com/advisories/1658) for [CVE-2021-28918](https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/)