### PR TITLE
fix: [41] pac-resolver > netmask high severity vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "get-uri": "3",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "5",
-    "pac-resolver": "^4.1.0",
+    "pac-resolver": "^4.2.0",
     "raw-body": "^2.2.0",
     "socks-proxy-agent": "5"
   },


### PR DESCRIPTION
pac-resolver dependency is using netmask version <= 2.0.0, this version is with a high severity vulnerability:
more info:

https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/
https://npmjs.com/advisories/1658
This bug is patched on netmask 2.0.1, and pac-resolver 4.2.0