### PR TITLE
bump pac-resolver 4.1.0 => 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "get-uri": "3",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "5",
-    "pac-resolver": "^4.1.0",
+    "pac-resolver": "^4.2.0",
     "raw-body": "^2.2.0",
     "socks-proxy-agent": "5"
   },


### PR DESCRIPTION
`pac-resolver` in 4.1.0 uses `netmask 1.0.6` with contains high severity vulnerability: https://www.npmjs.com/advisories/1658