### PR TITLE
fix: vm2 sec vuln CVE-2022-36067

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "get-uri": "3",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "5",
-    "pac-resolver": "^5.0.0",
+    "pac-resolver": "^5.0.1",
     "raw-body": "^2.2.0",
     "socks-proxy-agent": "5"
   },


### PR DESCRIPTION
resolves [issue 46](https://github.com/TooTallNate/node-pac-proxy-agent/issues/46) [CVE-2022-36067](https://nvd.nist.gov/vuln/detail/CVE-2022-36067) [GHSA-6pw2-5hjv-9pf7](https://github.com/advisories/GHSA-6pw2-5hjv-9pf7)